### PR TITLE
Add projects listing page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ import AlignmentWizard from "./pages/AlignmentWizard";
 import RimFaceWizard from "./pages/RimFaceWizard";
 import Reports from "./pages/Reports";
 import ReportPrint from "./pages/ReportPrint.jsx";
+import Projects from "./pages/Projects";
 
 // Componentes de layout
 import { Sidebar } from "./components/Sidebar";
@@ -30,6 +31,9 @@ function AppShell() {
 
             {/* Cálculos */}
             <Route path="calculations" element={<Calculations />} />
+
+            {/* Proyectos */}
+            <Route path="projects" element={<Projects />} />
 
             {/* Características */}
             <Route path="caracteristicas" element={<Caracteristicas />} />

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -8,6 +8,7 @@ import {
   ChevronRight,
   Cog,
   FileText,
+  FolderOpen,
   Home,
   LogOut,
   Sparkles,
@@ -19,6 +20,7 @@ import { useAuth } from "../hooks/use-auth";
 const API = import.meta.env.VITE_API_URL || "http://localhost:4000";
 const RAW_ITEMS = [
   { icon: Home, label: "Dashboard", href: "/app" },
+  { icon: FolderOpen, label: "Proyectos", href: "/app/projects" },
   { icon: Calculator, label: "Cálculos", href: "/app/calculations" },
   { icon: FileText, label: "Reportes", href: "/app/reports" },
   { icon: Sparkles, label: "Características", href: "/app/caracteristicas" },

--- a/src/pages/Projects.jsx
+++ b/src/pages/Projects.jsx
@@ -1,0 +1,355 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card";
+import { Badge } from "../components/ui/badge";
+import { Button } from "../components/ui/button";
+import { Input } from "../components/ui/input";
+import { Dialog } from "../components/ui/dialog";
+import { Clock, FolderOpen, Loader2, Plus } from "lucide-react";
+
+const API = import.meta.env.VITE_API_URL || "http://localhost:4000";
+
+function normalizeProject(project) {
+  if (!project || typeof project !== "object") return null;
+  return {
+    id: project.id ?? project.projectId ?? null,
+    name: project.name ?? project.title ?? "Proyecto sin nombre",
+    description: project.description ?? project.notes ?? "",
+    status: project.status ?? project.state ?? "EN_PROGRESO",
+    createdAt: project.createdAt ?? project.created_at ?? null,
+    updatedAt:
+      project.updatedAt ?? project.updated_at ?? project.createdAt ?? project.created_at ?? null,
+    owner: project.owner ?? project.ownerName ?? project.user ?? null,
+    machines: project.machines ?? project.assets ?? null,
+  };
+}
+
+function statusBadge(projectStatus) {
+  const s = (projectStatus || "").toUpperCase();
+  if (s === "COMPLETADO") return { label: "Completado", variant: "default", className: "bg-primary text-primary-foreground" };
+  if (s === "EN_PROGRESO") return { label: "En Progreso", variant: "secondary", className: "bg-secondary text-secondary-foreground" };
+  return { label: "Pendiente", variant: "outline", className: "" };
+}
+
+function formatDate(value) {
+  if (!value) return "-";
+  try {
+    const date = new Date(value);
+    return new Intl.DateTimeFormat("es-MX", {
+      dateStyle: "medium",
+      timeStyle: "short",
+    }).format(date);
+  } catch (err) {
+    console.error("No se pudo formatear la fecha", err);
+    return "-";
+  }
+}
+
+export default function Projects() {
+  const [projects, setProjects] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState("TODOS");
+  const [createOpen, setCreateOpen] = useState(false);
+  const [createName, setCreateName] = useState("");
+  const [createDescription, setCreateDescription] = useState("");
+  const [createLoading, setCreateLoading] = useState(false);
+  const [createError, setCreateError] = useState("");
+  const [refreshTick, setRefreshTick] = useState(0);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    let active = true;
+
+    async function loadProjects() {
+      setLoading(true);
+      setError("");
+      try {
+        const res = await fetch(`${API}/projects`, { credentials: "include" });
+        if (!res.ok) {
+          throw new Error(`Error ${res.status} al cargar proyectos`);
+        }
+        const body = await res.json().catch(() => []);
+        const list = Array.isArray(body?.items)
+          ? body.items
+          : Array.isArray(body?.projects)
+          ? body.projects
+          : Array.isArray(body)
+          ? body
+          : [];
+        const normalized = list.map(normalizeProject).filter(Boolean);
+        if (active) setProjects(normalized);
+      } catch (e) {
+        if (active) setError(e?.message || "No se pudieron cargar los proyectos");
+      } finally {
+        if (active) setLoading(false);
+      }
+    }
+
+    loadProjects();
+
+    return () => {
+      active = false;
+    };
+  }, [refreshTick]);
+
+  const filteredProjects = useMemo(() => {
+    const term = search.trim().toLowerCase();
+    return projects.filter((project) => {
+      const matchesTerm = !term
+        || project.name.toLowerCase().includes(term)
+        || project.description.toLowerCase().includes(term)
+        || (project.owner ? String(project.owner).toLowerCase().includes(term) : false);
+      const matchesStatus = statusFilter === "TODOS"
+        || (statusFilter === "EN_PROGRESO" && project.status?.toUpperCase() === "EN_PROGRESO")
+        || (statusFilter === "COMPLETADO" && project.status?.toUpperCase() === "COMPLETADO")
+        || (statusFilter === "PENDIENTE" && project.status?.toUpperCase() === "PENDIENTE");
+      return matchesTerm && matchesStatus;
+    });
+  }, [projects, search, statusFilter]);
+
+  function handleOpenProject(projectId) {
+    if (projectId == null) return;
+    navigate(`/app/calculations?project=${encodeURIComponent(projectId)}`);
+  }
+
+  function handleReload() {
+    setRefreshTick((tick) => tick + 1);
+  }
+
+  async function handleCreateProject(event) {
+    event?.preventDefault();
+    if (createLoading) return;
+    const name = createName.trim();
+    const description = createDescription.trim();
+
+    if (!name) {
+      setCreateError("Asigna un nombre al proyecto.");
+      return;
+    }
+
+    setCreateLoading(true);
+    setCreateError("");
+
+    try {
+      const res = await fetch(`${API}/projects`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({
+          name,
+          description: description || undefined,
+        }),
+      });
+
+      const contentType = res.headers.get("content-type") || "";
+      const isJson = contentType.includes("application/json");
+      const payload = isJson ? await res.json() : null;
+
+      if (!res.ok) {
+        const msg = payload?.error || payload?.message || `No se pudo crear el proyecto (${res.status})`;
+        throw new Error(msg);
+      }
+
+      const created = normalizeProject(payload?.project ?? payload);
+      if (!created) {
+        throw new Error("El servidor no devolvió el proyecto creado.");
+      }
+
+      setProjects((prev) => [created, ...prev]);
+      setCreateOpen(false);
+      setCreateName("");
+      setCreateDescription("");
+      handleReload();
+      navigate(`/app/calculations?project=${encodeURIComponent(created.id ?? "")}`);
+    } catch (err) {
+      console.error("[Projects] create error", err);
+      setCreateError(err?.message || "No se pudo crear el proyecto");
+    } finally {
+      setCreateLoading(false);
+    }
+  }
+
+  return (
+    <div className="p-6 space-y-6 max-w-6xl mx-auto">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="text-3xl font-bold text-foreground flex items-center gap-2">
+            <FolderOpen className="h-7 w-7" />
+            Mis proyectos
+          </h1>
+          <p className="text-muted-foreground mt-1">
+            Consulta el estado de tus proyectos de alineación y accede rápidamente a sus cálculos.
+          </p>
+        </div>
+        <Button
+          className="self-start bg-primary text-primary-foreground hover:opacity-90"
+          onClick={() => {
+            setCreateOpen(true);
+            setCreateError("");
+          }}
+        >
+          <Plus className="h-4 w-4 mr-2" />
+          Nuevo proyecto
+        </Button>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
+        <Input
+          placeholder="Buscar por nombre, responsable o descripción"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          className="md:col-span-1"
+        />
+        <div className="flex items-center gap-2">
+          {["TODOS", "EN_PROGRESO", "COMPLETADO", "PENDIENTE"].map((option) => (
+            <Button
+              key={option}
+              variant={statusFilter === option ? "default" : "outline"}
+              onClick={() => setStatusFilter(option)}
+            >
+              {option === "TODOS"
+                ? "Todos"
+                : option === "EN_PROGRESO"
+                ? "En progreso"
+                : option === "COMPLETADO"
+                ? "Completados"
+                : "Pendientes"}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      {error && (
+        <div className="text-sm text-destructive border border-destructive/30 rounded-md p-3">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex items-center justify-center py-16 text-muted-foreground gap-2">
+          <Loader2 className="h-5 w-5 animate-spin" /> Cargando proyectos...
+        </div>
+      ) : filteredProjects.length === 0 ? (
+        <Card className="bg-card">
+          <CardContent className="py-12 text-center space-y-2">
+            <Clock className="h-8 w-8 mx-auto text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">
+              {projects.length === 0
+                ? "Aún no tienes proyectos registrados."
+                : "No se encontraron proyectos que coincidan con los filtros actuales."}
+            </p>
+            <Button variant="outline" onClick={() => { setStatusFilter("TODOS"); setSearch(""); handleReload(); }}>
+              Actualizar lista
+            </Button>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          {filteredProjects.map((project) => {
+            const badge = statusBadge(project.status);
+            return (
+              <Card key={project.id ?? project.name} className="bg-card border-border">
+                <CardHeader className="space-y-1">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <CardTitle className="text-lg text-card-foreground leading-tight">
+                        {project.name}
+                      </CardTitle>
+                      {project.owner && (
+                        <p className="text-xs text-muted-foreground mt-1">Responsable: {project.owner}</p>
+                      )}
+                    </div>
+                    <Badge variant={badge.variant} className={badge.className}>
+                      {badge.label}
+                    </Badge>
+                  </div>
+                  <p className="text-xs text-muted-foreground">Actualizado {formatDate(project.updatedAt)}</p>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  {project.description ? (
+                    <p className="text-sm text-muted-foreground line-clamp-3">{project.description}</p>
+                  ) : (
+                    <p className="text-sm text-muted-foreground italic">
+                      Sin descripción registrada.
+                    </p>
+                  )}
+                  {Array.isArray(project.machines) && project.machines.length > 0 && (
+                    <div className="text-xs text-muted-foreground">
+                      <span className="font-medium text-card-foreground">Equipos:</span>{" "}
+                      {project.machines.join(", ")}
+                    </div>
+                  )}
+                  <div className="flex justify-end">
+                    <Button size="sm" variant="outline" onClick={() => handleOpenProject(project.id)}>
+                      Ver cálculos
+                    </Button>
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+
+      <Dialog
+        open={createOpen}
+        onClose={() => {
+          if (!createLoading) setCreateOpen(false);
+        }}
+        title="Nuevo proyecto"
+        footer={
+          <div className="flex justify-end gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              disabled={createLoading}
+              onClick={() => {
+                if (!createLoading) setCreateOpen(false);
+              }}
+            >
+              Cancelar
+            </Button>
+            <Button type="submit" form="create-project-form" disabled={createLoading}>
+              {createLoading ? "Creando..." : "Crear proyecto"}
+            </Button>
+          </div>
+        }
+      >
+        <form id="create-project-form" className="space-y-4" onSubmit={handleCreateProject}>
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-card-foreground" htmlFor="project-name">
+              Nombre del proyecto
+            </label>
+            <Input
+              id="project-name"
+              value={createName}
+              onChange={(event) => setCreateName(event.target.value)}
+              placeholder="Ej. Alineación Motor #7"
+              disabled={createLoading}
+              autoFocus
+            />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-card-foreground" htmlFor="project-description">
+              Descripción (opcional)
+            </label>
+            <textarea
+              id="project-description"
+              className="w-full min-h-[100px] rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
+              placeholder="Agrega notas, alcance del proyecto o responsables."
+              value={createDescription}
+              onChange={(event) => setCreateDescription(event.target.value)}
+              disabled={createLoading}
+            />
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Los proyectos te ayudan a agrupar cálculos y reportes relacionados con cada alineación.
+          </p>
+          {createError && <p className="text-sm text-destructive">{createError}</p>}
+        </form>
+      </Dialog>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated projects page with filtering, creation, and shortcuts to calculations
- expose the projects route in the application shell and navigation sidebar so it is easy to reach

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcdf419198832897166cb998a9cefe